### PR TITLE
Refactor jOOQ code generation to use profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,284 @@
                 <skipTests>false</skipTests>
             </properties>
         </profile>
+        <profile>
+            <id>jooq-codegen-testcontainers</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>testcontainers-jooq-codegen-maven-plugin</artifactId>
+                        <version>0.0.4</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.testcontainers</groupId>
+                                <artifactId>mysql</artifactId>
+                                <version>${testcontainers.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>com.mysql</groupId>
+                                <artifactId>mysql-connector-j</artifactId>
+                                <version>${mysql.jdbc.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>generate-jooq-sources</id>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <database>
+                                        <type>MYSQL</type>
+                                        <containerImage>mysql:8.0</containerImage>
+                                        <username>root</username> <!-- Use root because of permissions -->
+                                        <password>${db-password}</password>
+                                        <databaseName>${db-schema}</databaseName>
+                                    </database>
+                                    <flyway>
+                                        <!-- https://github.com/steve-community/steve/issues/157 -->
+                                        <initSql>SET default_storage_engine=InnoDB;</initSql>
+                                        <!-- we need this because of extensions. they have a higher version number
+                                             namespace reserved (e.g. 8.x.x). new migrations in core version should
+                                             be executed in the extended version as well -->
+                                        <outOfOrder>true</outOfOrder>
+
+                                        <!-- Because maven produces this warning after upgrading from 4.2.0 to 5.1.0:
+                                             [WARNING] Could not find schema history table `stevedb`.`flyway_schema_history`, but found
+                                             `stevedb`.`schema_version` instead. You are seeing this message because Flyway changed its
+                                             default for flyway.table in version 5.0.0 to flyway_schema_history and you are still relying
+                                             on the old default (schema_version). Set flyway.table=schema_version in your configuration to
+                                             fix this. This fallback mechanism will be removed in Flyway 6.0.0. -->
+                                        <table>schema_version</table>
+
+                                        <cleanDisabled>true</cleanDisabled>
+                                        <driver>${db-driver}</driver>
+                                        <url>${jdbcUrl}</url>
+                                        <user>${db-user}</user>
+                                        <password>${db-password}</password>
+                                        <schemas>
+                                            <schema>${db-schema}</schema>
+                                        </schemas>
+                                        <locations>
+                                            <location>filesystem:src/main/resources/db/migration</location>
+                                        </locations>
+                                    </flyway>
+                                    <!-- Generator parameters -->
+                                    <jooq>
+                                        <generator>
+                                            <database>
+                                                <name>org.jooq.meta.mysql.MySQLDatabase</name>
+                                                <includes>.*</includes>
+                                                <excludes/>
+                                                <inputSchema>${db-schema}</inputSchema>
+                                                <unsignedTypes>false</unsignedTypes>
+
+                                                <forcedTypes>
+                                                    <forcedType>
+                                                        <name>BOOLEAN</name>
+                                                        <!-- https://github.com/jOOQ/jOOQ/issues/7719 -->
+                                                        <includeTypes>(?i:(TINY|SMALL|MEDIUM|BIG)?INT(UNSIGNED)?\(1\))</includeTypes>
+                                                    </forcedType>
+                                                    <forcedType>
+                                                        <name>BOOLEAN</name>
+                                                        <includeExpression>.*\.OCPP_TAG_ACTIVITY\.(IN_TRANSACTION|BLOCKED)</includeExpression>
+                                                    </forcedType>
+                                                    <forcedType>
+                                                        <name>JSON</name>
+                                                        <includeExpression>.*\.WEB_USER\.(AUTHORITIES)</includeExpression>
+                                                    </forcedType>
+                                                </forcedTypes>
+                                            </database>
+                                            <generate>
+                                                <fluentSetters>true</fluentSetters>
+                                            </generate>
+                                            <target>
+                                                <packageName>jooq.steve.db</packageName>
+                                                <directory>${project.build.directory}/generated-sources</directory>
+                                            </target>
+                                        </generator>
+                                    </jooq>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jooq-codegen-flyway</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-maven-plugin</artifactId>
+                        <version>${flyway.version}</version>
+                        <executions>
+                            <execution>
+                                <id>flyway-migrate</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>migrate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <driver>${db-driver}</driver>
+                            <url>${jdbcUrl}</url>
+                            <user>${db-user}</user>
+                            <password>${db-password}</password>
+                            <schemas>
+                                <schema>${db-schema}</schema>
+                            </schemas>
+                            <locations>
+                                <location>filesystem:src/main/resources/db/migration</location>
+                            </locations>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq-codegen-maven</artifactId>
+                        <version>${jooq.version}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-jooq-sources</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <jdbc>
+                                <driver>${db-driver}</driver>
+                                <url>${jdbcUrl}</url>
+                                <user>${db-user}</user>
+                                <password>${db-password}</password>
+                            </jdbc>
+                            <generator>
+                                <database>
+                                    <name>org.jooq.meta.mysql.MySQLDatabase</name>
+                                    <includes>.*</includes>
+                                    <excludes/>
+                                    <inputSchema>${db-schema}</inputSchema>
+                                    <unsignedTypes>false</unsignedTypes>
+
+                                    <forcedTypes>
+                                        <forcedType>
+                                            <name>BOOLEAN</name>
+                                            <!-- https://github.com/jOOQ/jOOQ/issues/7719 -->
+                                            <includeTypes>(?i:(TINY|SMALL|MEDIUM|BIG)?INT(UNSIGNED)?\(1\))</includeTypes>
+                                        </forcedType>
+                                        <forcedType>
+                                            <name>BOOLEAN</name>
+                                            <includeExpression>.*\.OCPP_TAG_ACTIVITY\.(IN_TRANSACTION|BLOCKED)</includeExpression>
+                                        </forcedType>
+                                        <forcedType>
+                                            <name>JSON</name>
+                                            <includeExpression>.*\.WEB_USER\.(AUTHORITIES)</includeExpression>
+                                        </forcedType>
+                                    </forcedTypes>
+                                </database>
+                                <generate>
+                                    <fluentSetters>true</fluentSetters>
+                                </generate>
+                                <target>
+                                    <packageName>jooq.steve.db</packageName>
+                                    <directory>${project.build.directory}/generated-sources</directory>
+                                </target>
+                            </generator>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.mysql</groupId>
+                                <artifactId>mysql-connector-j</artifactId>
+                                <version>${mysql.jdbc.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>json-codegen</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.code.maven-replacer-plugin</groupId>
+                        <artifactId>replacer</artifactId>
+                        <version>1.5.3</version>
+                        <executions>
+                            <execution>
+                                <id>add-request-interface</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                                <configuration>
+                                    <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Request.json</filesToInclude>
+                                    <preserveDir>false</preserveDir>
+                                    <outputDir>${project.build.directory}/generated-resources</outputDir>
+                                    <replacements>
+                                        <replacement>
+                                            <token>"definitions"</token>
+                                            <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.RequestType"],
+                                              "definitions"</value>
+                                        </replacement>
+                                      </replacements>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>add-response-interface</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>replace</goal>
+                                </goals>
+                                <configuration>
+                                    <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Response.json</filesToInclude>
+                                    <preserveDir>false</preserveDir>
+                                    <outputDir>${project.build.directory}/generated-resources</outputDir>
+                                    <replacements>
+                                        <replacement>
+                                            <token>"definitions"</token>
+                                            <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.ResponseType"],
+                                              "definitions"</value>
+                                        </replacement>
+                                      </replacements>
+                                  </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jsonschema2pojo</groupId>
+                        <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                        <version>1.2.1</version>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/generated-resources</sourceDirectory>
+                            <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+                            <targetPackage>ocpp._2020._03</targetPackage>
+                            <generateBuilders>true</generateBuilders>
+                            <includeJsr303Annotations>true</includeJsr303Annotations>
+                            <includeGeneratedAnnotation>false</includeGeneratedAnnotation>
+                            <useJakartaValidation>true</useJakartaValidation>
+                            <dateType>java.time.LocalDate</dateType>
+                            <dateTimeType>java.time.OffsetDateTime</dateTimeType>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -374,174 +652,6 @@
                         <version>4.0.8</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>com.google.code.maven-replacer-plugin</groupId>
-                <artifactId>replacer</artifactId>
-                <version>1.5.3</version>
-                <executions>
-                    <execution>
-                        <id>add-request-interface</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                        <configuration>
-                            <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Request.json</filesToInclude>
-                            <preserveDir>false</preserveDir>
-                            <outputDir>${project.build.directory}/generated-resources</outputDir>
-                            <replacements>
-                                <replacement>
-                                    <token>"definitions"</token>
-                                    <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.RequestType"],
-                                      "definitions"</value>
-                                </replacement>
-                              </replacements>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>add-response-interface</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>replace</goal>
-                        </goals>
-                        <configuration>
-                            <filesToInclude>${basedir}/src/main/resources/OCPP-2.0.1_part3_JSON_schemas/*Response.json</filesToInclude>
-                            <preserveDir>false</preserveDir>
-                            <outputDir>${project.build.directory}/generated-resources</outputDir>
-                            <replacements>
-                                <replacement>
-                                    <token>"definitions"</token>
-                                    <value>"javaInterfaces" : ["de.rwth.idsg.ocpp.jaxb.ResponseType"],
-                                      "definitions"</value>
-                                </replacement>
-                              </replacements>
-                          </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jsonschema2pojo</groupId>
-                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>1.2.1</version>
-                <configuration>
-                    <sourceDirectory>${project.build.directory}/generated-resources</sourceDirectory>
-                    <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
-                    <targetPackage>ocpp._2020._03</targetPackage>
-                    <generateBuilders>true</generateBuilders>
-                    <includeJsr303Annotations>true</includeJsr303Annotations>
-                    <includeGeneratedAnnotation>false</includeGeneratedAnnotation>
-                    <useJakartaValidation>true</useJakartaValidation>
-                    <dateType>java.time.LocalDate</dateType>
-                    <dateTimeType>java.time.OffsetDateTime</dateTimeType>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-jooq-codegen-maven-plugin</artifactId>
-                <version>0.0.4</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.testcontainers</groupId>
-                        <artifactId>mysql</artifactId>
-                        <version>${testcontainers.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.mysql</groupId>
-                        <artifactId>mysql-connector-j</artifactId>
-                        <version>${mysql.jdbc.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>generate-jooq-sources</id>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <database>
-                                <type>MYSQL</type>
-                                    <containerImage>mysql:8.0</containerImage>
-                                    <username>root</username> <!-- Use root because of permissions -->
-                                    <password>${db-password}</password>
-                                    <databaseName>${db-schema}</databaseName>
-                            </database>
-                            <flyway>
-                                <!-- https://github.com/steve-community/steve/issues/157 -->
-                                <initSql>SET default_storage_engine=InnoDB;</initSql>
-                                <!-- we need this because of extensions. they have a higher version number
-                                     namespace reserved (e.g. 8.x.x). new migrations in core version should
-                                     be executed in the extended version as well -->
-                                <outOfOrder>true</outOfOrder>
-
-                                <!-- Because maven produces this warning after upgrading from 4.2.0 to 5.1.0:
-                                     [WARNING] Could not find schema history table `stevedb`.`flyway_schema_history`, but found
-                                     `stevedb`.`schema_version` instead. You are seeing this message because Flyway changed its
-                                     default for flyway.table in version 5.0.0 to flyway_schema_history and you are still relying
-                                     on the old default (schema_version). Set flyway.table=schema_version in your configuration to
-                                     fix this. This fallback mechanism will be removed in Flyway 6.0.0. -->
-                                <table>schema_version</table>
-
-                                <cleanDisabled>true</cleanDisabled>
-                                <driver>${db-driver}</driver>
-                                <url>${jdbcUrl}</url>
-                                <user>${db-user}</user>
-                                <password>${db-password}</password>
-                                <schemas>
-                                    <schema>${db-schema}</schema>
-                                </schemas>
-                                <locations>
-                                    <location>filesystem:src/main/resources/db/migration</location>
-                                </locations>
-                            </flyway>
-                            <!-- Generator parameters -->
-                            <jooq>
-                                <generator>
-                                    <database>
-                                        <name>org.jooq.meta.mysql.MySQLDatabase</name>
-                                        <includes>.*</includes>
-                                        <excludes/>
-                                        <inputSchema>${db-schema}</inputSchema>
-                                        <unsignedTypes>false</unsignedTypes>
-
-                                        <forcedTypes>
-                                            <forcedType>
-                                                <name>BOOLEAN</name>
-                                                <!-- https://github.com/jOOQ/jOOQ/issues/7719 -->
-                                                <includeTypes>(?i:(TINY|SMALL|MEDIUM|BIG)?INT(UNSIGNED)?\(1\))</includeTypes>
-                                            </forcedType>
-                                            <forcedType>
-                                                <name>BOOLEAN</name>
-                                                <includeExpression>.*\.OCPP_TAG_ACTIVITY\.(IN_TRANSACTION|BLOCKED)</includeExpression>
-                                            </forcedType>
-                                            <forcedType>
-                                                <name>JSON</name>
-                                                <includeExpression>.*\.WEB_USER\.(AUTHORITIES)</includeExpression>
-                                            </forcedType>
-                                        </forcedTypes>
-                                    </database>
-                                    <generate>
-                                        <fluentSetters>true</fluentSetters>
-                                    </generate>
-                                    <target>
-                                        <packageName>jooq.steve.db</packageName>
-                                        <directory>${project.build.directory}/generated-sources</directory>
-                                    </target>
-                                </generator>
-                            </jooq>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Done with google jules

Moves the Testcontainers-based jOOQ code generation to a dedicated profile, `jooq-codegen-testcontainers`, which is active by default.

Adds a new profile, `jooq-codegen-flyway`, that uses the `jooq-codegen-maven` and `flyway-maven-plugin` to generate jOOQ code against a running database instance. This provides an alternative to the Docker-dependent approach.

Additionally, the `replacer` and `jsonschema2pojo` plugins have been moved to a separate `json-codegen` profile to prevent them from interfering with the main build process.

Note: I was unable to run the tests in the development environment due to an issue connecting to the Docker daemon. The changes are based on the assumption that the Docker environment is correctly configured in the target environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modularized the build setup by moving code generation and migration plugin configurations into dedicated Maven profiles for improved organization.
  * Added new profiles for JSON code generation, JOOQ code generation with Testcontainers, and JOOQ code generation with Flyway.
  * No changes to plugin versions or configuration details; only the placement within the build process was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->